### PR TITLE
change PREFIX into DESTDIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,5 +18,5 @@ clean:
 	rm themes/*.edj
 
 install: $(THEMES_BIN)
-	mkdir -p "$(PREFIX)/usr/share/terminology/themes"
-	install -Dm644 $^ "$(PREFIX)/usr/share/terminology/themes"
+	mkdir -p "$(DESTDIR)/usr/share/terminology/themes"
+	install -Dm644 $^ "$(DESTDIR)/usr/share/terminology/themes"


### PR DESCRIPTION
First of all: Thank you for the awesome themes collection! :) I have just created a PR to get this into Gentoo: https://github.com/gentoo/gentoo/pull/5995

For automating ports, it should be `DESTDIR` instead of `PREFIX`. :)

Also see:
https://www.gnu.org/prep/standards/html_node/DESTDIR.html
https://www.freebsd.org/doc/en/books/porters-handbook/porting-prefix.html